### PR TITLE
Use generic IDs type in player service

### DIFF
--- a/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/AudioPlayerService.java
+++ b/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/AudioPlayerService.java
@@ -17,14 +17,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-public class AudioPlayerService extends Service {
+public class AudioPlayerService<ID> extends Service {
     private static final String LOG_TAG = AudioPlayerService.class.getSimpleName();
 
     private IBinder mBinder;
 
     private Handler mHandler;
 
-    private Map<Long, AudioPlayerHandler> mPlayers = new HashMap<>(6);
+    private Map<ID, AudioPlayerHandler> mPlayers = new HashMap<>(6);
 
     @Override
     public void onCreate() {
@@ -70,7 +70,7 @@ public class AudioPlayerService extends Service {
     }
 
     public class LocalBinder extends Binder {
-        public void register(long id, Uri fileUri, boolean showBufferIfPossible, AudioPlayerLayout view) {
+        public void register(ID id, Uri fileUri, boolean showBufferIfPossible, AudioPlayerLayout view) {
             AudioPlayerHandler player = mPlayers.get(id);
             if (player == null) {
                 player = onCreateAudioPlayerHandler(
@@ -88,7 +88,7 @@ public class AudioPlayerService extends Service {
             destroy();
         }
 
-        public void destroyPlayer(long id) {
+        public void destroyPlayer(ID id) {
             AudioPlayerHandler player = mPlayers.get(id);
             if (player != null) {
                 player.destroy();
@@ -96,7 +96,7 @@ public class AudioPlayerService extends Service {
         }
     }
 
-    public AudioPlayerHandler onCreateAudioPlayerHandler(Context context, long id, Uri fileUri,
+    public AudioPlayerHandler onCreateAudioPlayerHandler(Context context, ID id, Uri fileUri,
                                                          boolean showBufferIfPossible, Handler handler) {
         return new AudioPlayerHandler(context, fileUri, showBufferIfPossible, handler);
     }

--- a/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/AudioPlayerServiceManager.java
+++ b/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/AudioPlayerServiceManager.java
@@ -4,19 +4,19 @@ import com.heavyplayer.audioplayerrecorder.service.AudioPlayerService;
 
 import android.app.Activity;
 
-public class AudioPlayerServiceManager extends ServiceManager {
+public class AudioPlayerServiceManager<ID> extends ServiceManager {
     public AudioPlayerServiceManager(Activity activity) {
         this(activity, AudioPlayerService.class);
     }
 
-    public <T extends AudioPlayerService> AudioPlayerServiceManager(Activity activity, Class<T> serviceClass) {
+    public <T extends AudioPlayerService<ID>> AudioPlayerServiceManager(Activity activity, Class<T> serviceClass) {
         super(activity, serviceClass);
     }
 
     @Override
     protected void onDeactivateService(boolean stopService) {
         if (stopService) {
-            final AudioPlayerService.LocalBinder binder = getBinder();
+            final AudioPlayerService<ID>.LocalBinder binder = getBinder();
             if (binder != null) {
                 // Make sure the players are destroyed.
                 binder.destroyPlayers();
@@ -26,7 +26,7 @@ public class AudioPlayerServiceManager extends ServiceManager {
         super.onDeactivateService(stopService);
     }
 
-    public AudioPlayerService.LocalBinder getBinder() {
-        return (AudioPlayerService.LocalBinder) super.getBinder();
+    public AudioPlayerService<ID>.LocalBinder getBinder() {
+        return (AudioPlayerService<ID>.LocalBinder) super.getBinder();
     }
 }


### PR DESCRIPTION
Use generic IDs type in player service

Generic ID type `AudioPlayerService` allows using any ID type instead of locking on the specific one. It's useful when you want to associate players with custom objects.

Ref:
- related to - https://github.com/Doist/Todoist-Android/pull/3610 